### PR TITLE
Fix intra-word obfuscation and expand activity patterns

### DIFF
--- a/DEVELOPMENT_STATE.md
+++ b/DEVELOPMENT_STATE.md
@@ -1,7 +1,23 @@
 # Development State — Moltbot
 
 ## Current Task
-LLM-based verification challenge solver — complete, ready for commit.
+Fix verification challenge solver — intra-word obfuscation handling.
+
+## Plan — 2026-02-25
+
+### Block 21: Fix Intra-Word Obfuscation in Challenge Solver
+- [x] **21.1** Diagnose solver failures from heartbeat runs (runs 56-57 show solver failing)
+- [x] **21.2** Root cause: `_normalize_challenge_text` replaces intra-word separators with spaces, breaking words ("Tw^En]Ty" → "tw en ty" instead of "twenty")
+- [x] **21.3** Add `_strip_intra_word_separators()` helper — removes letter-sep-letter, spaces boundary-sep
+- [x] **21.4** Update `_normalize_challenge_text()` to use new helper
+- [x] **21.5** Update `_extract_number()` to deobfuscate before word scanning
+- [x] **21.6** Fix test_slash_separator_removed expectation ("newtons" not "new tons")
+- [x] **21.7** Add 10 new tests (3 normalization, 3 extract_number, 3 solver obfuscation, 1 test rename)
+- [x] **21.8** All 102 tests pass
+
+**Note on duplicate comments**: Originally investigated as duplicate-causing auto-verify on 200 responses. After reviewing heartbeat history (runs 54-57), confirmed that comments NEED verification to be published (run 55: "Verification passed — comment is published"). The auto-verify on 200 is correct behavior. The original duplicate suspension (Feb 9) may have been caused by the AI agent retrying after receiving a confusing verification response. The solver fix should reduce this by making verification succeed reliably.
+
+**Remaining**: Docker container on Zorin needs rebuild to deploy these fixes. Also, `data/logs/security_audit.jsonl` has permission denied in the container (moltbot user can't write to bind-mounted SMB volume) — challenge events only visible in docker logs.
 
 ## Uncommitted Work — 2026-02-20 (CLI Agent Session)
 

--- a/heartbeat/record_activity.py
+++ b/heartbeat/record_activity.py
@@ -61,7 +61,17 @@ COMMENT_PATTERNS = [
     ),
     # "Left a comment on X's post"
     re.compile(
-        r"[Ll]eft\s+(?:a|one)\s+comment\s+on\s+(?P<author>[\w\-]+)'s\s+(?:post|comment)\s+(?:about|on)?\s*(?P<detail>.+?)(?:\.|$)",
+        r"[Ll]eft\s+(?:a|one)\s+comment\s+on\s+(?P<author>[\w\-]+)'s\s+(?:post|comment|thread)\s+(?:about|on)?\s*(?P<detail>.+?)(?:\.|$)",
+        re.MULTILINE,
+    ),
+    # "Left a comment/reply connecting/drawing/about..."
+    re.compile(
+        r"[Ll]eft\s+(?:a|one)\s+(?:comment|reply)\s+(?P<detail>.+?)(?:\.\s|$)",
+        re.MULTILINE,
+    ),
+    # "Replied to X's post/thread"
+    re.compile(
+        r"[Rr]eplied\s+to\s+(?P<author>[\w\-]+)(?:'s)?\s+(?:post|thread|comment)\s+(?:about|on)\s+(?P<detail>.+?)(?:\s+[—\-]\s+|$)",
         re.MULTILINE,
     ),
     # "Commented on the X post"
@@ -96,14 +106,29 @@ WELCOME_PATTERNS = [
 ]
 
 BROWSE_PATTERNS = [
-    # "Browsed the hot/new feed"
+    # "Browsed/Read the hot/new feed"
     re.compile(
-        r"[Bb]rowsed\s+the\s+(?P<sort>hot|new|top|rising)\s+feed",
+        r"(?:[Bb]rowsed|[Rr]ead)\s+the\s+(?P<sort>hot|new|top|rising)\s+feed",
         re.MULTILINE,
     ),
-    # "Browsed m/community"
+    # "Read the feed" (no sort specified)
     re.compile(
-        r"[Bb]rowsed\s+(?:the\s+)?(?:m/)?(?P<community>[\w\-]+)\s+(?:submolt|feed|community)",
+        r"(?:[Bb]rowsed|[Rr]ead)\s+the\s+feed",
+        re.MULTILINE,
+    ),
+    # "Read a thread on X in m/community"
+    re.compile(
+        r"[Rr]ead\s+(?:a\s+)?(?:thread|post)\s+(?:on|about)\s+(?P<detail>.+?)(?:\s+in\s+(?:m/)?(?P<community>[\w\-]+))?(?:\.|$)",
+        re.MULTILINE,
+    ),
+    # "Read X's thread/post on Y"
+    re.compile(
+        r"[Rr]ead\s+(?P<author>[\w\-]+)'s\s+(?:thread|post)\s+(?:on|about)\s+(?P<detail>.+?)(?:\.|$)",
+        re.MULTILINE,
+    ),
+    # "Browsed m/community feed"
+    re.compile(
+        r"(?:[Bb]rowsed|[Rr]ead)\s+(?:the\s+)?(?:m/)(?P<community>[\w\-]+)(?:\s+(?:submolt|feed|community))?",
         re.MULTILINE,
     ),
 ]
@@ -232,8 +257,13 @@ def extract_actions(raw_output: str) -> list[dict]:
     for pattern in BROWSE_PATTERNS:
         for match in pattern.finditer(raw_output):
             groups = match.groupdict()
-            detail = groups.get("sort") or groups.get("community", "")
-            add_action("browsed", detail=detail)
+            detail = (
+                groups.get("sort")
+                or groups.get("detail")
+                or groups.get("community")
+                or ""
+            ).strip()
+            add_action("browsed", detail=detail or "feed")
 
     # Status check
     if STATUS_CHECK_PATTERN.search(raw_output):

--- a/server.py
+++ b/server.py
@@ -297,8 +297,11 @@ def _extract_number(text: str) -> float | None:
     if digit_matches:
         return float(digit_matches[-1])
 
+    # Strip intra-word obfuscation so "Tw^En]Ty" becomes "TwEnTy"
+    deobfuscated = _strip_intra_word_separators(text)
+
     # Scan for longest contiguous sequence of number words
-    words = re.findall(r"[a-z]+", text.lower())
+    words = re.findall(r"[a-z]+", deobfuscated.lower())
     best_num: float | None = None
     best_len = 0
 
@@ -318,15 +321,34 @@ def _extract_number(text: str) -> float | None:
     return best_num
 
 
+def _strip_intra_word_separators(text: str) -> str:
+    """Remove obfuscation characters embedded inside words.
+
+    Moltbook inserts separator chars (^, ], ~, etc.) within words:
+    'Tw^En]Ty' -> 'TwEnTy', 'NeW/ToNs' -> 'NeWToNs'
+    Separators at word boundaries are replaced with spaces:
+    'FiVe~ NeW' -> 'FiVe NeW', 'ClAw^' -> 'ClAw '
+    """
+    # Step 1: Remove separators between letters (intra-word)
+    cleaned = re.sub(
+        r"(?<=[a-zA-Z])[\]\[\^~|<>/{}()]+(?=[a-zA-Z])", "", text
+    )
+    # Step 2: Replace remaining separators with spaces (word boundaries)
+    cleaned = re.sub(r"[\]\[\^~|<>/{}()]+", " ", cleaned)
+    return cleaned
+
+
 def _normalize_challenge_text(text: str) -> str:
     """Strip obfuscation from challenge text.
 
     Moltbook challenges use mixed case and special-char separators:
     'A] LoB-stEr] ClAw^ ExErTs- ThIrTy] FiVe~ NeW/ToNs'
     -> 'a lobster claw exerts thirty five newtons'
+    Also handles intra-word separators:
+    'Tw^En]Ty Ei]GhT' -> 'twenty eight'
     """
-    # Replace common separator chars with spaces
-    cleaned = re.sub(r"[\]\[\^~|<>/{}()]+", " ", text)
+    # Strip intra-word separator chars, replace boundary ones with spaces
+    cleaned = _strip_intra_word_separators(text)
     # Replace hyphens surrounded by letters (intra-word) with nothing,
     # but keep standalone hyphens (minus signs between spaces)
     cleaned = re.sub(r"(?<=[a-zA-Z])-(?=[a-zA-Z])", "", cleaned)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import json
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 from typing import Dict, Any
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 import psycopg2
@@ -15,7 +16,48 @@ import psycopg2.extras
 # PostgreSQL test database fixtures
 # ---------------------------------------------------------------------------
 
-TEST_DATABASE_URL = os.environ.get(
+_TEST_DB_NAME = "moltbot_test"
+
+
+def _base_url_and_dbname(url: str) -> tuple[str, str]:
+    """Split a DATABASE_URL into (base_url_pointing_at_postgres_db, original_dbname)."""
+    parsed = urlparse(url)
+    original_db = parsed.path.lstrip("/")
+    base = urlunparse(parsed._replace(path="/postgres"))
+    return base, original_db
+
+
+def _create_test_db(base_url: str) -> str:
+    """Create the test database if it doesn't exist. Return its URL."""
+    conn = psycopg2.connect(base_url)
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT 1 FROM pg_database WHERE datname = %s", (_TEST_DB_NAME,)
+    )
+    if not cur.fetchone():
+        cur.execute(f"CREATE DATABASE {_TEST_DB_NAME}")
+    conn.close()
+
+    parsed = urlparse(base_url)
+    return urlunparse(parsed._replace(path=f"/{_TEST_DB_NAME}"))
+
+
+def _drop_test_db(base_url: str) -> None:
+    """Drop the test database, terminating any lingering connections."""
+    conn = psycopg2.connect(base_url)
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+        "WHERE datname = %s AND pid <> pg_backend_pid()",
+        (_TEST_DB_NAME,),
+    )
+    cur.execute(f"DROP DATABASE IF EXISTS {_TEST_DB_NAME}")
+    conn.close()
+
+
+_SOURCE_URL = os.environ.get(
     "TEST_DATABASE_URL",
     os.environ.get("DATABASE_URL", ""),
 )
@@ -23,15 +65,19 @@ TEST_DATABASE_URL = os.environ.get(
 
 @pytest.fixture
 def pg_database_url():
-    """Return the test database URL."""
-    return TEST_DATABASE_URL
+    """Return the test database URL (points at moltbot_test, never production)."""
+    if not _SOURCE_URL:
+        pytest.skip("DATABASE_URL / TEST_DATABASE_URL not set")
+    base_url, _ = _base_url_and_dbname(_SOURCE_URL)
+    return _create_test_db(base_url)
 
 
 @pytest.fixture
 def pg_clean_db(pg_database_url):
-    """Create a clean PostgreSQL database for testing.
+    """Create a clean PostgreSQL test database for testing.
 
-    Drops and recreates all tables before each test, then cleans up after.
+    Uses a dedicated ``moltbot_test`` database so production data is never
+    touched. Drops and recreates all tables before each test.
     Sets DATABASE_URL env var so dashboard.api.database picks it up.
     """
     old_url = os.environ.get("DATABASE_URL")
@@ -48,6 +94,7 @@ def pg_clean_db(pg_database_url):
 
     # Drop all tables in reverse dependency order
     cur.execute("""
+        DROP TABLE IF EXISTS blocked_authors CASCADE;
         DROP TABLE IF EXISTS behavior_oddities CASCADE;
         DROP TABLE IF EXISTS tool_calls CASCADE;
         DROP TABLE IF EXISTS security_events CASCADE;

--- a/tests/test_record_activity.py
+++ b/tests/test_record_activity.py
@@ -158,6 +158,62 @@ class TestExtractActions:
         assert "welcomed" in types
         assert "browsed" in types
 
+    def test_left_a_reply(self):
+        """Agent uses 'Left a reply' phrasing for comments."""
+        text = "Left a reply connecting mycorrhizal networks to the urban design argument."
+        actions = extract_actions(text)
+        comments = [a for a in actions if a["action_type"] == "commented"]
+        assert len(comments) == 1
+        assert "mycorrhizal" in comments[0]["detail"]
+
+    def test_replied_to_post(self):
+        """Agent uses 'Replied to X's post on Y' phrasing."""
+        text = "Replied to Clawhoven's post on music generation as a creativity proxy — pushed back."
+        actions = extract_actions(text)
+        comments = [a for a in actions if a["action_type"] == "commented"]
+        assert len(comments) == 1
+        assert comments[0]["target_author"] == "Clawhoven"
+        assert "music generation" in comments[0]["detail"]
+
+    def test_read_the_feed(self):
+        """Agent uses 'Read the feed' instead of 'Browsed the feed'."""
+        text = "Read the feed."
+        actions = extract_actions(text)
+        browsed = [a for a in actions if a["action_type"] == "browsed"]
+        assert len(browsed) == 1
+
+    def test_read_the_new_feed(self):
+        """Agent uses 'Read the new feed'."""
+        text = "Read the new feed."
+        actions = extract_actions(text)
+        browsed = [a for a in actions if a["action_type"] == "browsed"]
+        assert len(browsed) == 1
+        assert browsed[0]["detail"] == "new"
+
+    def test_read_thread_in_submolt(self):
+        """Agent uses 'Read a thread on X in m/community'."""
+        text = "Read a thread on mixed-use zoning in m/ponderings."
+        actions = extract_actions(text)
+        browsed = [a for a in actions if a["action_type"] == "browsed"]
+        assert len(browsed) == 1
+        assert "mixed-use zoning" in browsed[0]["detail"]
+
+    def test_realistic_celticxfer_output(self):
+        """Test with actual CelticXfer heartbeat output patterns."""
+        text = (
+            "Read the feed, found RabiaClawdBot's post on skill provenance. "
+            "Left a reply connecting the trust problem to mycelial networks "
+            "and upvoted the post."
+        )
+        actions = extract_actions(text)
+        types = [a["action_type"] for a in actions]
+        assert "commented" in types
+        assert "upvoted" in types
+        assert "browsed" in types
+        # Should NOT have a spurious browse with detail="the"
+        browsed = [a for a in actions if a["action_type"] == "browsed"]
+        assert all(b.get("detail") != "the" for b in browsed)
+
 
 # ---------------------------------------------------------------------------
 # extract_summary tests

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -925,14 +925,68 @@ class TestNormalizeChallengeText:
         result = _normalize_challenge_text("MoLt-InG")
         assert result == "molting"
 
-    def test_slash_separator_removed(self):
+    def test_slash_intra_word_removed(self):
+        """Slash between letters is intra-word obfuscation, not a word break."""
         result = _normalize_challenge_text("NeW/ToNs")
-        assert result == "new tons"
+        assert result == "newtons"
 
     def test_standalone_hyphen_preserved(self):
         """Hyphen between spaces (minus sign) should be preserved."""
         result = _normalize_challenge_text("ten - five")
         assert " - " in result
+
+    def test_intra_word_separator_preserved_as_word(self):
+        """Separators between letters should be stripped, not become spaces."""
+        result = _normalize_challenge_text("Tw^En]Ty")
+        assert result == "twenty"
+
+    def test_intra_word_multiple_separators(self):
+        """Multiple different intra-word separators in one word."""
+        result = _normalize_challenge_text("Ei]GhT")
+        assert result == "eight"
+
+    def test_mixed_intra_and_boundary_separators(self):
+        """Intra-word stripped, boundary-position replaced with space."""
+        result = _normalize_challenge_text("Tw^En]Ty] FiVe")
+        assert result == "twenty five"
+
+
+class TestExtractNumberObfuscated:
+    """Tests for _extract_number() with obfuscated text."""
+
+    def test_intra_word_separators(self):
+        result = _extract_number("Tw^En]Ty Ei]GhT")
+        assert result == 28.0
+
+    def test_single_obfuscated_word(self):
+        result = _extract_number("Se^VeN")
+        assert result == 7.0
+
+    def test_obfuscated_in_narrative(self):
+        result = _extract_number("a lobster claw^ exerts- Th^Ir]Ty~ FiVe| newtons")
+        assert result == 35.0
+
+
+class TestSolveChallengeRegexObfuscated:
+    """Tests for _solve_challenge_regex() with intra-word obfuscation."""
+
+    def test_intra_word_addition(self):
+        result = _solve_challenge_regex("Tw^En]Ty Ei]GhT + Fi^Ve")
+        assert result == "33.00"
+
+    def test_intra_word_subtraction(self):
+        result = _solve_challenge_regex(
+            "A] LoB-stEr] ClAw^ ExErTs- Th^Ir]Ty~ FiVe| NeW/ToNs "
+            "- AnOtHeR| Se^VeN"
+        )
+        assert result == "28.00"
+
+    def test_intra_word_narrative(self):
+        result = _solve_challenge_regex(
+            "A] LoB-stEr] ClAw^ ExErTs- Tw^En]Ty~ NeW/ToNs, "
+            "Um BuT^ MoLt-InG ReDuCeS| FoRce- By< Se^VeN> , WhAt^ ReMaInS?"
+        )
+        assert result == "13.00"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Fix challenge solver breaking obfuscated words (e.g., "Tw^En]Ty" → "twenty" instead of "tw en ty") by adding `_strip_intra_word_separators()` helper
- Expand heartbeat activity recording to handle new CelticXfer phrasing: "read the feed", "left a reply", "replied to X's post"
- Isolate test database into dedicated `moltbot_test` DB so tests never touch production data

## Test plan
- [ ] Verify all existing tests pass (`pytest tests/ -v`)
- [ ] Confirm new obfuscation tests cover intra-word separators in normalization, extraction, and regex solver
- [ ] Confirm new activity pattern tests match actual CelticXfer heartbeat output
- [ ] Verify test DB isolation creates and uses `moltbot_test` instead of production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)